### PR TITLE
LRCI-844 Skip dxp by default, filter dxp app dir

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -5,6 +5,7 @@
 ## named "test.${user.name}.properties" with the properties to overwrite.
 ##
 
+
 ##
 ## Test Batch
 ##


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-844

cc @petershin
This runs with this `liferay-portal-ee` 7.1.x branch: https://github.com/yichenroy/liferay-portal-ee/commits/LRCI-844-skip-dxp-by-default-7.1.x

This is the commit that does the filter:
https://github.com/yichenroy/liferay-portal-ee/commit/f6dfd1b0f77d6599e2e02660b2d957edefe0ee92